### PR TITLE
Fixed the main property so that wiredep can inject dependencies corre…

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,9 @@
 {
   "name": "JVFloat",
-  "main": "jvfloat.min.js, jvfloat.css",
+  "main": [
+    "jvfloat.min.js",
+    "jvfloat.css"
+  ],
   "version": "1.1.0",
   "homepage": "http://maman.github.io/JVFloat.js",
   "authors": [


### PR DESCRIPTION
…ctly

the [`main`](https://github.com/bower/bower.json-spec#main) property should be an array containing the entry-point files necessary to use the package. Strings only can be used if there is a single file to use from the package.

This will allow [wiredep](https://github.com/taptapship/wiredep) to run properly.
