### PR TITLE
Labels will no longer wrap if it contain more than one word

### DIFF
--- a/jvfloat.css
+++ b/jvfloat.css
@@ -31,6 +31,7 @@
 	transition: transform 150ms, opacity 100ms, visibility 100ms;
 	opacity: 0;
 	visibility: hidden;
+	white-space: nowrap;
 }
 
 /*Allows textarea floating placeholder to be positioned distinctly from the normal .placeHolder class


### PR DESCRIPTION
Fixed an issue where the floating labels sometimes where being wrapped on multiple lines in case it consist of more than one word.

Happened with Foundation 5.0
